### PR TITLE
Use pgpass file rather than $PGPASSWORD

### DIFF
--- a/.ebextensions/db.config
+++ b/.ebextensions/db.config
@@ -6,8 +6,12 @@ packages:
 files:
   "/etc/profile.d/z_psql.sh":
     content: |
-      export PGHOST="$DATABASE_HOST"
+      export PGHOST="${DATABASE_HOST}"
       export PGPORT=5432
       export PGDATABASE=safecast
       export PGUSER=safecast
-      export PGPASSWORD="$DATABASE_PASSWORD"
+
+      cat > ~/.pgpass <<EOF
+      ${DATABASE_HOST}:5432:safecast:safecast:${DATABASE_PASSWORD}
+      EOF
+      chmod 600 ~/.pgpass


### PR DESCRIPTION
Probably more secure, but mainly cause unsetting PGPASSWORD to connect to a different db is annoying