### PR TITLE
Remove location & captured_at columns

### DIFF
--- a/app/models/measurement.rb
+++ b/app/models/measurement.rb
@@ -9,11 +9,9 @@ end
 #
 # Table name: measurements
 #
-#  id          :integer          not null, primary key
-#  captured_at :datetime
-#  location    :geography({:srid point, 4326
-#  device_id   :integer          not null
-#  payload     :jsonb            not null
-#  created_at  :datetime
-#  updated_at  :datetime
+#  id         :integer          not null, primary key
+#  device_id  :integer          not null
+#  payload    :jsonb            not null
+#  created_at :datetime
+#  updated_at :datetime
 #

--- a/db/migrate/20170328122726_remove_captured_and_location_columns.rb
+++ b/db/migrate/20170328122726_remove_captured_and_location_columns.rb
@@ -1,0 +1,6 @@
+class RemoveCapturedAndLocationColumns < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :measurements, :captured_at
+    remove_column :measurements, :location
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -142,8 +142,6 @@ ALTER SEQUENCE devices_id_seq OWNED BY devices.numeric_id;
 
 CREATE TABLE measurements (
     id integer NOT NULL,
-    captured_at timestamp without time zone,
-    location geography(Point,4326),
     device_id bigint NOT NULL,
     payload jsonb NOT NULL,
     created_at timestamp without time zone DEFAULT now(),
@@ -235,13 +233,6 @@ ALTER TABLE ONLY schema_migrations
 
 
 --
--- Name: index_measurements_on_location; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_measurements_on_location ON measurements USING gist (location);
-
-
---
 -- Name: measurements update_measurements_updated_at; Type: TRIGGER; Schema: public; Owner: -
 --
 
@@ -265,6 +256,7 @@ INSERT INTO schema_migrations (version) VALUES
 ('20170210143343'),
 ('20170210151154'),
 ('20170212033722'),
-('20170314184402');
+('20170314184402'),
+('20170328122726');
 
 

--- a/spec/factories/measurement.rb
+++ b/spec/factories/measurement.rb
@@ -1,8 +1,6 @@
 FactoryGirl.define do
   factory :measurement do
-    captured_at { DateTime.current }
     device_id 12345678
-    location 'POINT(-70.78382 42.564835)'
     payload do
       { lora_snr: 7, lndp_cpm: 25, transport: 'http:50.250.38.70:46306' }
     end


### PR DESCRIPTION
These are no longer used. They may get introduced at some point later but likely not on the main db if my plans with pipelining pan out.