### PR TITLE
Switch metrics dump to a public gz

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ rvm:
   - 2.3.1
 addons:
   postgresql: "9.5"
+  apt:
+    packages:
+      - postgresql-9.5-postgis-2.3
 before_script:
   - cp config/database.yml.travis config/database.yml
   - psql -U postgres -c 'create database travis_ci_test'

--- a/cron/basic_csv_dump
+++ b/cron/basic_csv_dump
@@ -2,4 +2,8 @@
 
 source db_settings.env
 source export_db_settings.env
-psql -f basic_csv_dump.sql | aws s3 cp - "${EXPORT_TARGET}"/csv/measurements.csv
+psql -f basic_csv_dump.sql |\
+  gzip -c |\
+  aws s3 cp - "${EXPORT_TARGET}"/csv/measurements.csv.gz \
+  --acl public-read \
+  --cache-control "max-age=300"


### PR DESCRIPTION
Requested by Pieter in https://safecast.slack.com/archives/C026F2Q1U/p1502594300000006

See https://s3-us-west-2.amazonaws.com/safecastdata-us-west-2/ingest/dev/csv/measurements.csv.gz for an example

Connected to https://github.com/Safecast/safecastapi/issues/378