### PR TITLE
Data pipelining to s3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,9 @@ gem 'pg'
 gem 'otr-activerecord'
 gem 'activerecord-postgis-adapter'
 
+# data pipeline
+gem 'aws-sdk-sns', '~> 1'
+
 group :development do
   gem 'rerun'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -32,4 +32,5 @@ group :development, :test do
   gem 'annotate'
   gem 'factory_girl'
   gem 'dotenv'
+  gem 'pry'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,8 @@ gem 'activerecord-postgis-adapter'
 
 # data pipeline
 gem 'aws-sdk-sns', '~> 1'
+gem 'aws-sdk-sqs', '~> 1'
+gem 'aws-sdk-s3', '~> 1'
 
 group :development do
   gem 'rerun'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,15 @@ GEM
       rake (>= 0.8.7)
     arel (7.1.4)
     awesome_print (1.7.0)
+    aws-partitions (1.18.0)
+    aws-sdk-core (3.2.0)
+      aws-partitions (~> 1.0)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-sns (1.0.0)
+      aws-sdk-core (~> 3)
+      aws-sigv4 (~> 1.0)
+    aws-sigv4 (1.0.2)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
@@ -76,6 +85,7 @@ GEM
       hashie (>= 3.0)
     i18n (0.7.0)
     ice_nine (0.11.2)
+    jmespath (1.3.1)
     json (2.0.3)
     jsonapi (0.1.1.beta6)
       jsonapi-parser (= 0.1.1.beta3)
@@ -165,6 +175,7 @@ DEPENDENCIES
   active_model_serializers
   activerecord-postgis-adapter
   annotate
+  aws-sdk-sns (~> 1)
   database_cleaner
   dotenv
   factory_girl

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,17 @@ GEM
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
+    aws-sdk-kms (1.0.0)
+      aws-sdk-core (~> 3)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-s3 (1.1.0)
+      aws-sdk-core (~> 3)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.0)
     aws-sdk-sns (1.0.0)
+      aws-sdk-core (~> 3)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-sqs (1.0.0)
       aws-sdk-core (~> 3)
       aws-sigv4 (~> 1.0)
     aws-sigv4 (1.0.2)
@@ -175,7 +185,9 @@ DEPENDENCIES
   active_model_serializers
   activerecord-postgis-adapter
   annotate
+  aws-sdk-s3 (~> 1)
   aws-sdk-sns (~> 1)
+  aws-sdk-sqs (~> 1)
   database_cleaner
   dotenv
   factory_girl

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
     builder (3.2.2)
     case_transform (0.2)
       activesupport
+    coderay (1.1.1)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.0.4)
@@ -87,6 +88,7 @@ GEM
       ruby_dep (~> 1.2)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
+    method_source (0.8.2)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
     multi_json (1.12.1)
@@ -101,6 +103,10 @@ GEM
       activerecord (>= 4.0, < 5.1)
       hashie-forbidden_attributes (~> 0.1)
     pg (0.19.0)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     puma (3.6.2)
     rack (2.0.1)
     rack-accept (0.4.5)
@@ -141,6 +147,7 @@ GEM
     ruby_dep (1.5.0)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
+    slop (3.6.0)
     thread_safe (0.3.5)
     tool (0.2.3)
     tzinfo (1.2.2)
@@ -165,6 +172,7 @@ DEPENDENCIES
   grape_logging
   otr-activerecord
   pg
+  pry
   puma
   rack-test
   rake
@@ -177,4 +185,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/Rakefile
+++ b/Rakefile
@@ -29,3 +29,13 @@ end
 namespace :db do
   task environment: :environment
 end
+
+namespace :workers do
+  task s3_raw: :environment do
+    Workers::S3Raw.new(
+      ENV.fetch('INPUT_QUEUE_URL', 'https://sqs.us-west-2.amazonaws.com/985752656544/ingest-measurements-to-s3-raw-dev'),
+      ENV.fetch('OUTPUT_BUCKET_NAME', 'safecastdata-us-west-2'),
+      ENV.fetch('OBJECT_PREFIX', 'ingest/dev/s3raw')
+    ).run
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -27,22 +27,5 @@ task :environment do
 end
 
 namespace :db do
-  task :environment do
-    require_relative 'application'
-  end
-
-  # To correct for https://github.com/Safecast/ingest/pull/2/files#diff-5835da67485dd547fb9545b67446cc53R7
-  # Can remove after being deployed & run on prd env
-  desc 'JSON parse any string measurement payloads'
-  task fix_payload_escaping: :environment do
-    Measurement.all.each do |m|
-      if m.payload.is_a? String
-        begin
-          m.update!(payload: JSON.parse(m.payload))
-        rescue => e
-          $stderr.puts "Error (#{e.message}): measurement id=#{m.id}"
-        end
-      end
-    end
-  end
+  task environment: :environment
 end

--- a/app/lib/measurements/creator.rb
+++ b/app/lib/measurements/creator.rb
@@ -1,3 +1,5 @@
+require 'aws-sdk-sns'
+
 module Measurements
   class Creator
     def initialize(payload)
@@ -6,10 +8,17 @@ module Measurements
     end
 
     def create!
-      Measurement.create!(
+      measurement = Measurement.create!(
         device_id: @device_id,
         payload: @payload
       )
+
+      if ENV['MEASUREMENTS_TOPIC_ARN']
+        topic = Aws::SNS::Topic.new(ENV['MEASUREMENTS_TOPIC_ARN'])
+        topic.publish(message: {version: 1, payload: @payload}.to_json)
+      end
+
+      measurement
     end
   end
 end

--- a/app/workers/batch.rb
+++ b/app/workers/batch.rb
@@ -1,0 +1,21 @@
+require 'logger'
+
+module Workers
+  class Batch
+    attr_reader :interval, :logger
+
+    def initialize(interval: nil, logger: ::Logger.new($stdout))
+      @interval = interval || (ENV['WORKER_INTERVAL'] || 3600).to_i
+      @logger = logger
+    end
+
+    def run
+      logger.progname = self.class.to_s
+      logger.info("Starting worker with #{interval} second interval")
+      loop do
+        work
+        sleep interval
+      end
+    end
+  end
+end

--- a/app/workers/s3_raw.rb
+++ b/app/workers/s3_raw.rb
@@ -1,0 +1,45 @@
+require 'aws-sdk-sqs'
+require 'aws-sdk-s3'
+
+module Workers
+  class S3Raw < Batch
+    attr_reader :queue, :bucket, :object_prefix
+
+    def initialize(input_queue_url, output_bucket_name, object_prefix, interval: nil)
+      super(interval: interval)
+
+      @queue = Aws::SQS::Queue.new(input_queue_url)
+      @bucket = Aws::S3::Bucket.new(output_bucket_name)
+      @object_prefix = object_prefix
+    end
+
+    def work
+      key = [object_prefix, Time.now.utc.strftime('%Y-%m-%d/%H/%M')].join('/')
+
+      write_location = "s3://#{bucket.name}/#{key}"
+      logger.info("Starting batch from #{queue.url} to #{write_location}")
+
+      batched_messages = []
+      loop do
+        messages = queue.receive_messages(max_number_of_messages: 10)
+        batched_messages += messages.to_a
+        break if messages.size == 0
+      end
+
+      if batched_messages.empty?
+        logger.info('No messages to process')
+      else
+        logger.info("Batching #{batched_messages.size} messages")
+
+        body = batched_messages.map { |message|
+          JSON.parse(message.body)['Message']
+        }.join("\n\n")
+
+        bucket.put_object(key: key, body: body)
+        logger.info("Wrote #{body.size} bytes to #{write_location}")
+
+        batched_messages.each { |m| m.delete }
+      end
+    end
+  end
+end

--- a/application.rb
+++ b/application.rb
@@ -15,7 +15,8 @@ OTR::ActiveRecord.configure_from_file!(
   %w(app serializers ** *.rb),
   %w(app serializers *.rb),
   %w(app api ** *.rb),
-  %w(app api *.rb)
+  %w(app api *.rb),
+  %w(app workers *.rb)
 ].each do |pattern|
   Dir.glob(Config.root.join(*pattern)).each { |file| require file }
 end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,6 +3,7 @@ require 'pathname'
 require 'bundler'
 
 # Load environment settings
+# noinspection RubyConstantNamingConvention
 Config = OpenStruct.new
 Config.env = ENV['RACK_ENV'] ? ENV['RACK_ENV'].to_sym : :development
 Config.root = Pathname.new(File.expand_path('../..', __FILE__))
@@ -11,6 +12,7 @@ Bundler.require(:default, Config.env)
 
 if Config.env != :production
   require 'dotenv'
+  # noinspection RubyArgCount
   Dotenv.load(
     Config.root.join('.env.local'),
     Config.root.join(".env.#{Config.env}"),

--- a/spec/app/api/v1/measurements_spec.rb
+++ b/spec/app/api/v1/measurements_spec.rb
@@ -33,5 +33,19 @@ describe API::V1::Measurements, type: :api do
       expect(last_response.status).to eq 201
     end
 
+    let(:stub_client) { double(:aws_sns_topic) }
+
+    it 'publishes to SNS if measurements_topic_arn is provided' do
+      ENV['MEASUREMENTS_TOPIC_ARN'] = 'arn:fake:topic'
+
+      expect(Aws::SNS::Topic).to receive(:new).and_return(stub_client)
+      expect(stub_client).to receive(:publish)
+
+      post '/v1/measurements', { device: 1337 }
+      expect(last_response.status).to eq 201
+
+      ENV.delete('MEASUREMENTS_TOPIC_ARN')
+    end
+
   end
 end


### PR DESCRIPTION
Changes the measurements creator to also publish to SNS if MEASUREMENTS_TOPIC_ARN is present.

Also sets up a prototypical worker which writes all received data to s3 once per hour by default.

Connected to https://github.com/Safecast/safecastapi/issues/356