### PR TITLE
Create index on payload.service_md5 of measturements table

### DIFF
--- a/db/migrate/20171015140634_add_index_to_payload_service_md5_on_measurements.rb
+++ b/db/migrate/20171015140634_add_index_to_payload_service_md5_on_measurements.rb
@@ -1,0 +1,11 @@
+class AddIndexToPayloadServiceMd5OnMeasurements < ActiveRecord::Migration[5.0]
+  def up
+    execute(<<-SQL.strip_heredoc)
+      CREATE INDEX measurements_payload_service_md5_index ON measurements USING BTREE ((payload->>'service_md5'))
+    SQL
+  end
+
+  def down
+    execute('DROP INDEX IF EXISTS measurements_payload_service_md5_index')
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.6.1
--- Dumped by pg_dump version 9.6.1
+-- Dumped from database version 9.6.5
+-- Dumped by pg_dump version 9.6.5
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -233,6 +233,20 @@ ALTER TABLE ONLY schema_migrations
 
 
 --
+-- Name: measurements_payload_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX measurements_payload_idx ON measurements USING gin (payload);
+
+
+--
+-- Name: measurements_payload_service_md5_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX measurements_payload_service_md5_index ON measurements USING btree (((payload ->> 'service_md5'::text)));
+
+
+--
 -- Name: measurements update_measurements_updated_at; Type: TRIGGER; Schema: public; Owner: -
 --
 
@@ -257,6 +271,7 @@ INSERT INTO schema_migrations (version) VALUES
 ('20170210151154'),
 ('20170212033722'),
 ('20170314184402'),
-('20170328122726');
+('20170328122726'),
+('20171015140634');
 
 


### PR DESCRIPTION
This PR should create an index on `service_md5` in `payload` column of `measurements` table. I would like to create index because I would like to use this data to check existence of same data. (See #32) Without index, query like `SELECT COUNT(id) FROM measurements WHERE payload ->> 'service_md5'` would do whole table scan.

Connected to https://github.com/Safecast/safecastapi/issues/352