### PR TITLE
More worker fixups

### DIFF
--- a/.ebextensions/00_base.config
+++ b/.ebextensions/00_base.config
@@ -1,0 +1,10 @@
+packages:
+  yum:
+    jq: []
+
+commands:
+  parameters_cache:
+    command: |
+      /opt/aws/bin/cfn-get-metadata --region `{"Ref": "AWS::Region"}` --stack `{"Ref": "AWS::StackName"}` \
+        --resource AWSEBBeanstalkMetadata --key AWS::ElasticBeanstalk::Ext |
+        jq .Parameters > /etc/elasticbeanstalk/parameters-cache

--- a/.ebextensions/workers.config
+++ b/.ebextensions/workers.config
@@ -1,4 +1,29 @@
+files:
+  "/etc/init/worker_elastic_cloud.conf":
+    content: |
+      description "Start worker for writing points to elastic cloud"
+
+      start on runlevel [2345]
+      stop on runlevel [!2345]
+
+      script
+        cd /var/app/current
+        sudo -u webapp bash -lc 'rake workers:elastic_cloud' | logger -t worker_elastic_cloud
+      end script
+
 commands:
+  start_worker_elastic_cloud:
+    command: |
+      if grep -q ELASTIC_CLOUD_INPUT_QUEUE_URL /etc/elasticbeanstalk/parameters-cache; then
+        if status worker_elastic_cloud | grep -q running; then
+          restart worker_elastic_cloud
+        else
+          start worker_elastic_cloud
+        fi
+      else
+        echo manual > /etc/init/worker_elastic_cloud.override
+      fi
+
   match_nginx_timeout_to_sqs_timeout:
     command: |
       VISIBILITY_TIMEOUT=$(jq -r .AWSEBVisibilityTimeout /etc/elasticbeanstalk/parameters-cache)

--- a/.ebextensions/workers.config
+++ b/.ebextensions/workers.config
@@ -1,0 +1,8 @@
+commands:
+  match_nginx_timeout_to_sqs_timeout:
+    command: |
+      VISIBILITY_TIMEOUT=$(jq -r .AWSEBVisibilityTimeout /etc/elasticbeanstalk/parameters-cache)
+      if [[ -n "${VISIBILITY_TIMEOUT}" ]]; then
+        echo "proxy_read_timeout ${VISIBILITY_TIMEOUT}s;" > /etc/nginx/conf.d/worker.conf
+        service nginx restart
+      fi

--- a/app/workers/elastic_cloud.rb
+++ b/app/workers/elastic_cloud.rb
@@ -99,6 +99,9 @@ module Workers
                           :'ingest.location' => {
                               type: 'geo_point',
                               ignore_malformed: true
+                          },
+                          pms_std01_0: {
+                              type: 'float'
                           }
                       }
                   }


### PR DESCRIPTION
Connected to https://github.com/Safecast/safecastapi/issues/411

Fixes the alarms that started yesterday when the cron jobs started running > 1m

Also changes the elastic cloud worker to an upstart job so it'll (1) run on all worker hosts and (2) restart if there's an exception.