### PR TITLE
Use the semaphore cache as a build artifact store

### DIFF
--- a/.elasticbeanstalk/deploy.sh
+++ b/.elasticbeanstalk/deploy.sh
@@ -2,17 +2,39 @@
 
 # Helper for deploying a packaged app to elasticbeanstalk.
 #
-# Expects $BRANCH_NAME and $SEMAPHORE_BUILD_NUMBER to be provided by the environment.
+# Expected environment variables (should be set set by semaphore)
+#   - BRANCH_NAME
+#   - SEMAPHORE_BUILD_NUMBER
+#   - EB_APP_NAME
+#   - EB_ENV_NAME
+#   - AWS_DEFAULT_REGION
+#   - S3_BUCKET_NAME
 #
-# Usage: .elasticbeanstalk/deploy.sh APP ENVIRONMENT
-# Ex: .elasticbeanstalk/deploy.sh "${EB_APP_NAME}" "${EB_ENV_NAME}"
+# Optional environment variables
+#   - CREATE_APPLICATION_VERSION - set to "true" to also create the application version in s3/elasticbeanstalk
+#   - ARTIFACT_EXPIRATION        - when to expire old artifacts during post-deploy cleanup (default: 90 days)
 
 set -euo pipefail
 
-EB_APP_NAME="${1}"
-EB_ENV_NAME="${2}"
+CREATE_APPLICATION_VERSION="${CREATE_APPLICATION_VERSION:-false}"
+ARTIFACT_EXPIRATION="${ARTIFACT_EXPIRATION:-129600}"
 
 VERSION="${EB_APP_NAME}-${BRANCH_NAME}-${SEMAPHORE_BUILD_NUMBER}"
+PACKAGE="${VERSION}.zip"
+
+if [[ "${CREATE_APPLICATION_VERSION}" == "true" ]]; then
+    echo "Creating application version ${VERSION}..."
+    aws s3 cp --no-progress ".semaphore-cache/artifacts/${PACKAGE}" "s3://${S3_BUCKET_NAME}/${EB_APP_NAME}/"
+    aws elasticbeanstalk create-application-version \
+      --region "${AWS_DEFAULT_REGION}" \
+      --application-name "${EB_APP_NAME}" \
+      --version-label "${VERSION}" \
+      --source-bundle "S3Bucket=${S3_BUCKET_NAME},S3Key=${EB_APP_NAME}/${PACKAGE}" \
+      --process
+fi
 
 echo "Deploying ${VERSION} to ${EB_ENV_NAME}..."
-eb deploy "${EB_ENV_NAME}" --version "${VERSION}" --timeout 20
+eb deploy --quiet "${EB_ENV_NAME}" --version "${VERSION}" --timeout 20
+
+echo "Cleaning up any build artifacts older than 90 days"
+find ".semaphore-cache/artifacts" -type f -mmin "${ARTIFACT_EXPIRATION}" -delete

--- a/.elasticbeanstalk/package.sh
+++ b/.elasticbeanstalk/package.sh
@@ -5,6 +5,9 @@
 # Expected environment variables (should be set set by semaphore)
 #   - BRANCH_NAME
 #   - SEMAPHORE_BUILD_NUMBER
+#
+# Usage: .elasticbeanstalk/package.sh APP
+# Ex: .elasticbeanstalk/package.sh ${SEMAPHORE_PROJECT_NAME}
 
 set -euo pipefail
 

--- a/.elasticbeanstalk/package.sh
+++ b/.elasticbeanstalk/package.sh
@@ -16,6 +16,9 @@ BUCKET="${3}"
 PACKAGE="${APP}-${BRANCH_NAME}-${SEMAPHORE_BUILD_NUMBER}.zip"
 
 .elasticbeanstalk/package.py "${PACKAGE}"
+
+cp ".elasticbeanstalk/app_versions/${PACKAGE}" .semaphore-cache
+
 aws s3 cp --no-progress ".elasticbeanstalk/app_versions/${PACKAGE}" "s3://${BUCKET}/${APP}/"
 aws elasticbeanstalk create-application-version \
   --region "${REGION}" \

--- a/.elasticbeanstalk/package.sh
+++ b/.elasticbeanstalk/package.sh
@@ -2,26 +2,17 @@
 
 # Helper for packaging the app for elasticbeanstalk deployment.
 #
-# Expects $BRANCH_NAME and $SEMAPHORE_BUILD_NUMBER to be provided by the environment.
-#
-# Usage: .elasticbeanstalk/package.sh APP REGION BUCKET
-# Ex: .elasticbeanstalk/package.sh ingest us-west-2 elasticbeanstalk-us-west-2-985752656544
+# Expected environment variables (should be set set by semaphore)
+#   - BRANCH_NAME
+#   - SEMAPHORE_BUILD_NUMBER
 
 set -euo pipefail
 
-APP="${1}"
-REGION="${2}"
-BUCKET="${3}"
+EB_APP_NAME="${1}"
 
-PACKAGE="${APP}-${BRANCH_NAME}-${SEMAPHORE_BUILD_NUMBER}.zip"
+PACKAGE="${EB_APP_NAME}-${BRANCH_NAME}-${SEMAPHORE_BUILD_NUMBER}.zip"
 
 .elasticbeanstalk/package.py "${PACKAGE}"
 
-cp ".elasticbeanstalk/app_versions/${PACKAGE}" .semaphore-cache
-
-aws s3 cp --no-progress ".elasticbeanstalk/app_versions/${PACKAGE}" "s3://${BUCKET}/${APP}/"
-aws elasticbeanstalk create-application-version \
-  --region "${REGION}" \
-  --application-name "${APP}" \
-  --version-label "${APP}-${BRANCH_NAME}-${SEMAPHORE_BUILD_NUMBER}" \
-  --source-bundle "S3Bucket=${BUCKET},S3Key=${APP}/${PACKAGE}"
+mkdir -p .semaphore-cache/artifacts
+cp ".elasticbeanstalk/app_versions/${PACKAGE}" .semaphore-cache/artifacts


### PR DESCRIPTION
Initially I had the "build" stage also push artifacts to s3.

This was nice to save on initial deploy time, but risked exposure of keys since anyone can open an PR here with code modified to echo keys to the build output or copy them elsewhere.

This switches the build step to be package-only, writing to the semaphore cache.

Then the deploy script will (optionally) upload to s3, create the app version and prune old zip files from the semaphore cache.

This ensures that only code specifically deployed by semaphore collaborators or code merged to master will handle AWS keys.

See https://semaphoreci.com/safecast/ingest/servers/dev/deploys/10 for example deploy from build

Connected to https://github.com/Safecast/safecastapi/issues/346