### PR TITLE
Reindexing for 2019

### DIFF
--- a/db/curator/README.md
+++ b/db/curator/README.md
@@ -7,6 +7,7 @@ To run them use:
 ```
 IFS='' read -rs CURATOR_PASSWORD && export CURATOR_PASSWORD
 (type or paste in password for the "elastic" user and press return. ask mat for the password)
+export CURATOR_AUTH="elastic:${CURATOR_PASSWORD}"
 curator --config curator.yml yearly_reindex.yml --dry-run
 ```
 
@@ -14,8 +15,8 @@ Please use caution as there's not really any "undo" for any of this stuff. We ha
 
 ## yearly_reindex.yml
 
-Reindexes all 2018 daily indices into a single yearly index
+Reindexes all 2019 daily indices into a single yearly index
 
 ## yearly_delete.yml
 
-Deletes all the 2018 daily indices. For use after reindexing.
+Deletes all the 2019 daily indices. For use after reindexing.

--- a/db/curator/curator.yml
+++ b/db/curator/curator.yml
@@ -3,8 +3,7 @@ client:
     - 40ad140d461d810ac41ed710b5c7a5b6.us-west-2.aws.found.io
   port: 9243
   use_ssl: True
-  username: elastic
-  password: ${CURATOR_PASSWORD}
+  http_auth: ${CURATOR_AUTH}
   timeout: 30
 
 logging:

--- a/db/curator/yearly_delete.yml
+++ b/db/curator/yearly_delete.yml
@@ -1,6 +1,6 @@
 actions:
   0:
-    description: "Set 2018 daily indices to writable"
+    description: "Set 2019 daily indices to writable"
     action: index_settings
     options:
       index_settings:
@@ -9,11 +9,11 @@ actions:
     filters:
       - filtertype: pattern
         kind: prefix
-        value: ingest-measurements-2018-
+        value: ingest-measurements-2019-
   1:
-    description: "Delete 2018 daily indices"
+    description: "Delete 2019 daily indices"
     action: delete_indices
     filters:
       - filtertype: pattern
         kind: prefix
-        value: ingest-measurements-2018-
+        value: ingest-measurements-2019-

--- a/db/curator/yearly_reindex.yml
+++ b/db/curator/yearly_reindex.yml
@@ -1,6 +1,6 @@
 actions:
   0:
-    description: "Set 2018 daily indices to readonly"
+    description: "Set 2019 daily indices to readonly"
     action: index_settings
     options:
       index_settings:
@@ -9,9 +9,9 @@ actions:
     filters:
       - filtertype: pattern
         kind: prefix
-        value: ingest-measurements-2018-
+        value: ingest-measurements-2019-
   1:
-    description: "Reindex 2018 daily indices into yearly"
+    description: "Reindex 2019 daily indices into yearly"
     action: reindex
     options:
       wait_interval: 9
@@ -20,8 +20,8 @@ actions:
         source:
           index: REINDEX_SELECTION
         dest:
-          index: ingest-measurements-2018
+          index: ingest-measurements-2019
     filters:
       - filtertype: pattern
         kind: prefix
-        value: ingest-measurements-2018-
+        value: ingest-measurements-2019-


### PR DESCRIPTION
Elasticsearch is working on a feature that should simplify the use of https://www.elastic.co/guide/en/elasticsearch/reference/current/index-lifecycle-management.html

So with any luck 2020 will be the last time we need to do this, then we can just switch to that and not muck with reindexing at all. 